### PR TITLE
Added "subcommands" to switch layers

### DIFF
--- a/src/cmdline/ansi.h
+++ b/src/cmdline/ansi.h
@@ -248,7 +248,7 @@ void ansi_disable();
 // (i.e., 24-bit RGB), but we'll stick to basic attributes and 3-bit.
 // Get ANSI escape sequence based on current settings
 
-/*
+
 const char *ansi_get_reset();
 const char *ansi_get_red();
 const char *ansi_get_green();
@@ -305,8 +305,12 @@ bool enable_vt_mode() {
     return true;
 }
 #elif defined(_WIN32)
+// Newer Windows 10 and 11 versions support ANSI colors in the console
+// and Windows Terminal, but they have to be enabled manually:
 // https://learn.microsoft.com/en-us/windows/console/
 //     console-virtual-terminal-sequences
+//
+// TODO: Older console versions do have formatting, but it's not ANSI.
 bool enable_vt_mode() {
     HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
     if (hOut == INVALID_HANDLE_VALUE) {
@@ -327,7 +331,6 @@ bool enable_vt_mode() {
 }
 #endif
 
-*/
 
 
 #endif // ANSI_H

--- a/src/cmdline/docs.h
+++ b/src/cmdline/docs.h
@@ -5,7 +5,7 @@
 
 
 // NOTE: All of the command-line outputs herein conform to the RFC 678
-// plaintext document standard it is good readability practice to limit
+// plaintext document standard; it is good readability practice to limit
 // a line of code's columns to 72 characters (which include only the
 // printable characters, not line endings or cursors).
 //     I specifically chose 72 (and not some other limit like 80/132)
@@ -32,6 +32,7 @@ _Pragma ("once")
 #ifndef DOCS_H
 #define DOCS_H
 
+// TODO: Do I use ANSI code to color these?
 
 // TODO: Do I use \r\n here, or continue relying on libc?
 // TODO: Create a man.1 (man page) file using this
@@ -42,6 +43,11 @@ _Pragma ("once")
 // NOTE: Unfortunately, C preprocessor is unable to include actual .txt
 // files (which could otherwise be holding this text) into strings.
 // (C23 is apparently able to do this using the new #embed directive.)
+
+static const char HELP_TEXT_BANNER[] = "\
+test\n\
+";
+
 static const char HELP_TEXT_OVERVIEW[] = "\
 Usage: blitzping [options]\n\
 \n\
@@ -54,7 +60,7 @@ conventions, and the \"=\" sign may be omitted.\n\
 ::::::::::::::::::::::::::::::::General:::::::::::::::::::::::::::::::::\n\
 -? --help=<command>         Display this help message or more info.\n\
 -! --about                  Display information about the Program.\n\
--V --version                Display the Program version.\n\
+-V --version                Display the Program's version.\n\
 -Q --quiet                  Suppress all output except errors.\n\
 ::::::::::::::::::::::::::::::::Advanced::::::::::::::::::::::::::::::::\n\
 -$ --bypass-checks          Ignore system compatibility issues (e.g., \n\
@@ -79,6 +85,11 @@ conventions, and the \"=\" sign may be omitted.\n\
                             (May reduce performance.)\n\
    --no-cpu-prefetch        Don't prefetch packet buffer to CPU cache.\n\
                             (May reduce performance.)\n\
+   --no-zero-copy           By default, and only on GNU/Linux 2.4+, the\n\
+                            Program uses shared ring buffers as a kernel\n\
+                            bypass method; this flag will disable said\n\
+                            feature on otherwise-supported platforms.\n\
+                            (Will severely hinder performance.)\n\
 ";
 
 // TODO: Have a layer 2 ether and "raw" (no protocol) layer 3 option.

--- a/src/main.c
+++ b/src/main.c
@@ -81,6 +81,7 @@ void diagnose_system(struct ProgramArgs *const program_args) {
 #endif
 
 /*
+// TODO: use capabilities to also verify privilage level in raw sockets
     // Check to see if the currently running machine's endianness
     // matches what was expected to be the target's endianness at
     // the time of compilation.
@@ -146,7 +147,7 @@ void fill_defaults(struct ProgramArgs *const program_args) {
 }
 
 int main(int argc, char *argv[]) {
-     struct ProgramArgs program_args = {0};
+    struct ProgramArgs program_args = {0};
     struct ip_hdr *ipv4_header_args = 
         (struct ip_hdr *)calloc(1, sizeof(struct ip_hdr));
 
@@ -190,8 +191,10 @@ int main(int argc, char *argv[]) {
     logger_set_level(program_args.general.logger_level);
     logger_set_timestamps(!program_args.advanced.no_log_timestamp);
 
-    int socket_descriptor = create_raw_async_socket();
-    if (socket_descriptor == EXIT_FAILURE) {
+    int socket_descriptor = setup_posix_socket(
+        true, !program_args.advanced.no_async_sock
+    ); // TODO: make raw sockets optional
+    if (socket_descriptor == -1) {
         program_args.diagnostics.unrecoverable_error = true;
         logger(LOG_INFO, "Quitting after failing to create a socket.");
         goto CLEANUP;

--- a/src/netlib/netinet.h
+++ b/src/netlib/netinet.h
@@ -63,9 +63,9 @@ _Pragma ("once")
 // endianness control is crucial. (C23 N3030)
 // Check for C23 support
 #if __STDC_VERSION__ >= 202300L // C23 or later
-#   define ENUM_UNDERLYING(type) : type
+#    define ENUM_UNDERLYING(type) : type
 #else // Fallback for older standards (e.g., C11)
-#   define ENUM_UNDERLYING(type) __attribute__((packed))
+#    define ENUM_UNDERLYING(type) __attribute__((packed))
 #endif
 
 
@@ -78,15 +78,32 @@ _Pragma ("once")
 
 
 /* Protocol Definitions */
+// TODO: Separete protos into layer names in their folders.
 #include "./protos/ip.h"
 #include "./protos/tcp.h"
 
-typedef enum osi_layer {
-    LAYER_2,
-    LAYER_3,
-    LAYER_4
+typedef enum OsiLayer {
+    LAYER_0 = 0, // None (doesn't exist)
+    LAYER_1 = 1, // MAC/Ethernet
+    LAYER_2 = 2, // IPv4/IPv6
+    LAYER_3 = 3, // 
+    LAYER_4 = 4, // 
+    LAYER_5 = 5, // 
+    LAYER_6 = 6, // 
+    LAYER_7 = 7, // 
+
+    // Aliases
+    LAYER_NONE         = LAYER_0,
+    LAYER_PHYSICAL     = LAYER_1,
+    LAYER_DATALINK     = LAYER_2,
+    LAYER_NETWORK      = LAYER_3,
+    LAYER_TRANSPORT    = LAYER_4,
+    LAYER_SESSION      = LAYER_5,
+    LAYER_PRESENTATION = LAYER_6,
+    LAYER_APPLICATION  = LAYER_7
 } osi_layer_t;
 
+// TODO: We don't have namespaces, but can we somehow group this in OSI?
 typedef enum osi_protocol {
     // Layer 3 (Network)
     PROTO_L3_RAW,
@@ -96,7 +113,7 @@ typedef enum osi_protocol {
     PROTO_L4_RAW,
     PROTO_L4_TCP,
     PROTO_L4_UDP,
-    PROTO_L4_ICMP // ICMP shouldn't belong in L3.
+    PROTO_L4_ICMP // TODO: ICMP shouldn't belong in L4.
 } osi_proto_t;
 
 

--- a/src/packet.h
+++ b/src/packet.h
@@ -40,9 +40,10 @@ typedef union {
 #   if defined(_POSIX_THREADS) && _POSIX_THREADS >= 0
 #       include <pthread.h>
 #   endif
-#   include <arpa/inet.h>
+#   include <poll.h>
 #   include <sys/mman.h>
 #   include <sys/uio.h>
+#   include <arpa/inet.h>
 #elif defined(_WIN32)
 //#include <winsock2.h>
 #endif

--- a/src/socket.c
+++ b/src/socket.c
@@ -7,28 +7,206 @@
 #include "socket.h"
 
 
-int create_raw_async_socket() {
+#if defined(_POSIX_C_SOURCE)
+
+// NOTE: Document somewhere that raw sockets would require
+// enabling the "Mirrored" networking mode for WSL2.
+int setup_posix_socket(const bool is_raw, const bool is_async) {
     // Setting the 'errno' flag to 0 indicates "no errors" so
     // that a previously set value does not affect us.
     errno = 0;
 
-    // Attempt to create a raw socket.
+    int sock_opts = 0;
+    sock_opts |= is_raw ? SOCK_RAW : SOCK_STREAM;
+
+    // Attempt to create the specified socket.
+    // https://stackoverflow.com/questions/49309029
+    // TODO: Kernel fills-in IPs whenever they are zero'ed; find
+    // a way to actually let the 0 pass unchanged.
+    // TODO: see if pf_packet + bind() is faster
+    // TODO: MSG_DONTROUTE?
+    // TODO: MSG_OOB  and out-of-bound?
     int socket_descriptor = socket(
-        AF_INET,                  // Domain
-        SOCK_RAW | SOCK_NONBLOCK, // Type (+ options)
-        IPPROTO_RAW               // Protocol (implies IP_HDRINCL)
+        AF_INET,    // Domain
+        sock_opts,  // Type (+ options)
+        IPPROTO_RAW // Protocol (implies IP_HDRINCL)
     );
 
-    // Check for errors.
 	if (socket_descriptor == -1) {
 		// Socket creation failed (maybe non-root privileges?)
-		perror("Failed to create an asynchronous raw socket");
-        return EXIT_FAILURE;
+        logger(LOG_CRIT,
+                "Failed to create POSIX socket: %s", strerror(errno));
+        return -1;
 	}
 
-    // On success, return the socket descriptor.
+    // NOTE: This, under Linux, would have been a one-liner:
+    //     sock_opts |= is_async ? SOCK_NONBLOCK : 0;
+    // Unfortunately, that is a Linux-only and non-POSIX-compliant way;
+    // POSIX 2001 requires using O_NONBLOCK with fcntl() instead.
+    if (is_async) {
+        // Get the current flags for the socket
+        int flags = fcntl(socket_descriptor, F_GETFL, 0);
+        if (flags == -1) {
+            logger(LOG_ERROR,
+                "Failed to get socket flags: %s", strerror(errno));
+            return -1;
+        }
+
+        flags |= O_NONBLOCK;
+
+        int status = fcntl(socket_descriptor, F_SETFL, flags);
+        if (status == -1) {
+            logger(LOG_ERROR,
+                "Failed to set socket to asynchronous mode: %s",
+                strerror(errno));
+            return -1;
+        }
+    }
+
+
     return socket_descriptor;
 }
+
+#   if defined(__linux__)
+
+// AF_PACKET + SOCK_RAW is the "lowest" you can go in terms of raw
+// sockets; they're also known as a packet-socket.  However, unlike
+// the above function, they aren't POSIX-compliant.
+//     The most important advantage of packet-sockets is that they
+// let you memory-map (mmap) them using shared ring buffers, bypassing
+// most kernel layers and removing some of the overhead of syscalls:
+//     https://stackoverflow.com/questions/49309029
+//     https://docs.kernel.org/networking/packet_mmap.html
+//     https://blog.cloudflare.com/kernel-bypass/
+//     https://stackoverflow.com/questions/4873956/
+int setup_mmap_socket(const char *const interface_name) {
+    // NOTE: A protocol of 0 means we only want to transmit packets via
+    // this socket; this will avoid expensive syscalls to packet_rcv().
+    const int socket_descriptor = socket(
+        AF_PACKET,
+        SOCK_RAW,
+        0
+    );
+    if (socket_descriptor == -1) {
+        logger(LOG_CRIT,
+            "Failed to create packet-socket: %s", strerror(errno));
+        return -1;
+    }
+
+    // Identifies the link-layer "address" and protocol:
+    //     https://stackoverflow.com/questions/70995951/
+    // TODO: On systems with multiple network interfaces, see if
+    // passing 0 to sll_ifindex improves performance.
+    const struct sockaddr_ll socket_address = {
+        .sll_family = AF_PACKET,
+        .sll_protocol = 0,
+        .sll_ifindex = if_nametoindex(interface_name)
+    };
+    if (socket_address.sll_ifindex == 0) {
+        logger(LOG_CRIT,
+            "Failed to get interface index: %s", strerror(errno));
+        return -1;
+    }
+
+    // Bind the socket
+    const int bind_status = bind(
+        socket_descriptor,
+        (struct sockaddr*)&socket_address,
+        sizeof(socket_address)
+    );
+    if (bind_status == -1) {
+        logger(LOG_ERROR,
+            "Failed to bind the socket: %s", strerror(errno));
+        return -1;
+    }
+
+    // Set up the PACKET_TX_RING option
+    // TODO: Make these configurable and also calculate maximums
+    // https://www.kernel.org/doc/Documentation/networking/pktgen.txt
+    // https://www.reddit.com/r/golang/comments/1bcexhp/
+    const struct tpacket_req ring_buffer_cfg = {
+        .tp_block_size = 4096,
+        .tp_block_nr = 64,
+        .tp_frame_size = 4096,
+        .tp_frame_nr = 64
+    };
+    const int opt_status = setsockopt(
+        socket_descriptor,
+        SOL_PACKET,
+        PACKET_TX_RING,
+        &ring_buffer_cfg,
+        sizeof(ring_buffer_cfg)
+    );
+    if (opt_status == -1) {
+        logger(LOG_ERROR,
+            "Failed to set PACKET_TX_RING option: %s", strerror(errno));
+        return -1;
+    }
+
+    // Memory-map the ring buffer to user-space
+    const void *const map = mmap(
+        NULL,
+        ring_buffer_cfg.tp_block_size * ring_buffer_cfg.tp_block_nr,
+        PROT_READ | PROT_WRITE,
+        MAP_SHARED,
+        socket_descriptor,
+        0
+    );
+    if (map == MAP_FAILED) {
+        logger(LOG_ERROR,
+            "Failed to memory-map packet-socket's ring buffer: %s",
+            strerror(errno)
+        );
+        return -1;
+    }
+
+    // TODO: PACKET_QDISC_BYPASS seems very promising  (kernel 3.14+)
+    // TODO: MSG_ZEROCOPY vs. af_packet?
+    
+    // The socket is now ready to use with the mapped buffer
+    return socket_descriptor;
+}
+
+// TODO: Investigate AF_XDP, as it appears to have the potential to
+// be faster than packet-sockets, but it might also require loading
+// BPF objects into kernel and/or having specific models of NICs. (?)
+// Other than running directly on the NIC (where very few smartNICs
+// even support this capability), you can also hook the XDP in the
+// driver itself (again, without widespreads upport); finally,
+// you may also run the XDP in a "generic" SKB mode, which seems to
+// defeat its performance benefits and also prevent zero-copy'ing.
+//     https://www.youtube.com/watch?v=hO2tlxURXJ0
+//     https://qmonnet.github.io/whirl-offload/2016/09/01/dive-into-bpf
+//     https://github.com/xdp-project/
+//         xdp-project/blob/master/areas/drivers/README.org
+//     https://pantheon.tech/what-is-af_xdp
+//     https://stackoverflow.com/questions/78990613/
+//     https://forum.suricata.io/t/
+//         difference-between-af-packet-mode-and-af-xdp-mode/4754
+//     https://stackoverflow.com/questions/
+//     https://blog.cloudflare.com/
+//         a-story-about-af-xdp-network-namespaces-and-a-cookie/
+//     https://blog.freifunk.net/2024/05/31/gsoc-2024-ebpf-
+//         performance-optimizations-for-a-new-openwrt-firewall/
+//     https://toonk.io/building-an-xdp-express-data-path-
+//         based-bgp-peering-router/index.html
+//     https://www.netdevconf.org/0x14/pub/slides/37/
+//         Adding%20AF_XDP%20zero-copy%20support%20to%20drivers.pdf
+// Also, it appears that AF_XDP is the "successor" to AF_PACKET v3;
+// AF_PACKET v4 never seems to have taken off (?):
+//     https://lore.kernel.org/netdev/
+//         95aaafdc-ef8a-c4b9-6104-a1a753c81820@intel.com/
+//     https://lwn.net/Articles/737947/
+//     https://www.netdevconf.info/2.2/slides/karlsson-afpacket-talk.pdf
+//     https://www.youtube.com/watch?v=RSFX7z1qF2g
+//
+// Ultimately, it appears that the "fastest" method is to write our
+// own driver for a specific NIC, but that is obviously not portable.
+// (DPDK, VPP, libpcap, etc. do exactly this for a handful of NICs.)
+
+#   endif /* defined(__linux__) */
+
+#endif /* defined(_POSIX_C_SOURCE) */
 
 
 // ---------------------------------------------------------------------

--- a/src/socket.h
+++ b/src/socket.h
@@ -3,18 +3,29 @@
 // socket.h is a part of Blitzping.
 // ---------------------------------------------------------------------
 
+
 #pragma once
 #ifndef SOCKET_H
 #define SOCKET_H
 
+#include "./cmdline/logger.h"
+
+#include <string.h>
+#include <stdbool.h>
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>
 
 #if defined(_POSIX_C_SOURCE)
+#   include <fcntl.h>
+#   include <sys/mman.h>
 #   include <sys/socket.h>
 #   include <arpa/inet.h>
+#   include <net/if.h>
+#   if defined(__linux__)
+#       include <linux/if_packet.h>
+#   endif
 #elif defined(_WIN32)
 //#include <winsock2.h>
 #endif
@@ -22,7 +33,7 @@
 extern int errno; // Declared in <errno.h>
 
 
-int create_raw_async_socket();
+int setup_posix_socket(const bool is_raw, const bool is_async);
 
 
 #endif // SOCKET_H


### PR DESCRIPTION
As of now, the parser had no way of knowing which option belonged to which protocol; for instance, both IPv4 and TCP have *chksum* fields in their headers, and `Blitzping --chksum=123` was ambigious.

I thought of several ways to differentiate/switch protocols, such as namespaces (`--tcp-chksum`, `--ipv4-chksum`), using colons (`--chksum=tcp:123;ipv4:456`), and utilizing existing options (`-T` / `--tcp`; `-U` / `--UDP`; `-4` / `--ipv4`; etc.)  All of these resulted in an unwieldy user interface and/or overcomplicated the parser.

So, rather than options or fixed-position arguments, I settled on "subcommands," such as `layer3`/`l3`/`network`/`net`/`packet` and `layer4`/`l4`/`transport`/`trans`/`segment`/`datagram`.

```
Blitzping --some-option \
    layer3 chksum=123 \
    layer4 chskum=456
```